### PR TITLE
setup fixes

### DIFF
--- a/bin/run.sh
+++ b/bin/run.sh
@@ -5,6 +5,8 @@ docker-compose up -d db
 sleep 10
 echo "Bringing up tomcat"
 docker-compose up -d tomcat_oscar
+
+sleep 5
 docker-compose up -d nginx
 
 echo "OSCAR is set up at http://<this host>/oscar"

--- a/build-source.sh
+++ b/build-source.sh
@@ -16,5 +16,5 @@ if [ ! -f drugref2.war ]; then
   docker run -v $(pwd):/code/ busybox sh -c "cd /code/ && wget $DRUGREF_WAR -O drugref2.war"
 fi
 
-docker-compose build tomcat_oscar
+./setup-oscar-release.sh
 

--- a/deploy-source.sh
+++ b/deploy-source.sh
@@ -7,6 +7,3 @@ echo "This deploys a fresh oscar from source."
 echo "Compiling OSCAR. This may take some time...."
 
 ./build-source.sh
-
-./bin/run.sh
-

--- a/setup-oscar-release.sh
+++ b/setup-oscar-release.sh
@@ -9,7 +9,7 @@ DB_PASSWORD=$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 13 ; echo '')
 # if this is a fresh install
 if [ ! -f oscar.properties ]; then
   echo "copying oscar properties template"
-  cp ./conf/templates/oscar_mcmaster_bc.properties oscar.properties
+  cp ./conf/templates/oscar_mcmaster_bc.properties ./oscar.properties
 fi
 
 if [ ! -f drugref.properties ]; then


### PR DESCRIPTION
This avoids the error.
`ERROR: for tomcat_oscar  Cannot start service tomcat_oscar: OCI runtime create failed: container_linux.go:345: starting container process caused "process_linux.go:424: container init caused \"rootfs_linux.go:58: mounting \\\"/home/ferdinand/work/open-osp/drugref2.properties\\\" to rootfs \\\"/var/lib/docker/overlay2/53e27e48a65ee8214cadb438a6c4e69f18a62c041bd9b775a00c089298cc230c/merged\\\" at \\\"/var/lib/docker/overlay2/53e27e48a65ee8214cadb438a6c4e69f18a62c041bd9b775a00c089298cc230c/merged/root/drugref2.properties\\\" caused \\\"not a directory\\\"\"": unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type`

This happens because tomcat_oscar is built first and the volumes drugref and oscar properties are build as folders. This branch will now, do setup-oscar-release, to copy properties and build the tomcat_oscar