### PR TITLE
add general logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       image: mariadb:10.4
       command: 'mysqld --character-set-server=utf8 --collation-server=utf8_general_ci'
       working_dir: /code
-      env_file: 
+      env_file:
         - local.env
       environment:
         MYSQL_DATABASE: drugref2
@@ -36,8 +36,8 @@ services:
       networks:
         - back-tier
       environment:
-        TZ: America/Vancouver  
-        
+        TZ: America/Vancouver
+
     expedius:
       restart: 'always'
       image: openosp/expedius:latest
@@ -51,7 +51,7 @@ services:
         - back-tier
       environment:
         TZ: America/Vancouver
-        
+
     faxws:
       restart: 'always'
       image: openosp/faxws:latest
@@ -67,7 +67,7 @@ services:
       environment:
         TZ: America/Vancouver
         MYSQL_HOST: db
-        
+
 volumes:
   mariadb-files:
     driver: local
@@ -75,5 +75,3 @@ volumes:
 networks:
   back-tier:
     driver: bridge
-
-

--- a/docker/db/my.cnf
+++ b/docker/db/my.cnf
@@ -84,8 +84,8 @@ query_cache_size		= 64M
 # Both location gets rotated by the cronjob.
 # Be aware that this log type is a performance killer.
 # As of 5.1 you can enable the log at runtime!
-#general_log_file        = /var/log/mysql/mysql.log
-#general_log             = 1
+general_log_file        = /var/log/mysql/mysql.log
+general_log             = 1
 #
 # Error logging goes to syslog due to /etc/mysql/conf.d/mysqld_safe_syslog.cnf.
 #


### PR DESCRIPTION
@countable the way to look at logs now is going into the container and tailing /var/log/mysql/mysql.log. Is this what we wanted? 