### PR TITLE
Hotfix clone params

### DIFF
--- a/bin/build-oscar.sh
+++ b/bin/build-oscar.sh
@@ -3,7 +3,12 @@
 
 set -uxo
 
-./bin/clone.sh
+if [ -f "./local.env" ]
+then
+    source ./local.env
+fi
+
+./bin/clone.sh ${OSCAR_REPO:-""} ${OSCAR_TREEISH:-""}
 
 cd docker/oscar/oscar
 

--- a/bin/openosp-bootstrap.sh
+++ b/bin/openosp-bootstrap.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
+if [ -f "./local.env" ]
+then
+    source ./local.env
+fi
+
 echo "Setting up database..."
 docker-compose up -d db
 sleep 10
 
-docker-compose -f docker-compose.build.yml run -T builder ./bin/clone.sh
+docker-compose -f docker-compose.build.yml run -T builder ./bin/clone.sh ${OSCAR_REPO:-""} ${OSCAR_TREEISH:-""}
 docker-compose exec -T db ./bin/populate-db.sh
 


### PR DESCRIPTION
Fixes #98 . This branch fixes a bug where scripts calling ./bin/clone.sh doesn't consider OSCAR_TREEISH and OSCAR_REPO from local.env.