### PR TITLE
Fix: Expedius Dockerfile base image

### DIFF
--- a/docker/expedius/Dockerfile
+++ b/docker/expedius/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:8.5-jre
+FROM tomcat:8.5-jre8
 
 # Fetch Expedius binary
 RUN wget https://bitbucket.org/colcamexdev/expediusbinary/downloads/Expedius-4.12.19.war


### PR DESCRIPTION
The expedius build fails on a fresh setup with the error:

```
Building expedius
Step 1/5 : FROM tomcat:8.5-jre
ERROR: Service 'expedius' failed to build: manifest for tomcat:8.5-jre not found: manifest unknown: manifest unknown
```