### PR TITLE
Fix #133 by specifying faxws container name with dashes

### DIFF
--- a/bin/setup-faxws.sh
+++ b/bin/setup-faxws.sh
@@ -27,7 +27,7 @@ docker-compose exec db mysql -h localhost -uroot -p$MYSQL_ROOT_PASSWORD -e "crea
 # [cvo] use sql bootstrap instead for now.
 #docker-compose exec faxws bash -c "cd /usr/local/tomcat/webapps/faxWs/META-INF/maven/oscarFax/FaxWs && mvn flyway:migrate -Dflyway.user=root -Dflyway.password=tzcbU/u87wM= -Dflyway.url=jdbc:mysql://db/oscarFax"
 dcid=$(pwd | grep -oh "[^/]*$")
-docker cp ${dcid}_faxws_1:/create_database.sql _bootstrap.sql
+docker cp ${dcid}-faxws-1:/create_database.sql _bootstrap.sql
 
 docker-compose exec db bash -c "mysql -h localhost -uroot -p$MYSQL_ROOT_PASSWORD OscarFax < _bootstrap.sql"
 rm _bootstrap.sql


### PR DESCRIPTION
The docker container name should be specified with dashes and not underscores, to avoid this error when running `./openosp bootstrap`

Error: No such container:path: work_faxws_1:/create_database.sql
bash: _bootstrap.sql: No such file or directory
rm: cannot remove '_bootstrap.sql': No such file or directory

This fixes #133 