### PR TITLE
Magenta improvements

### DIFF
--- a/bin/openosp-bootstrap.sh
+++ b/bin/openosp-bootstrap.sh
@@ -9,7 +9,7 @@ echo "Setting up database..."
 docker-compose up -d db
 sleep 10
 
-docker-compose -f docker-compose.build.yml run -T builder ./bin/clone.sh ${OSCAR_REPO:-""} ${OSCAR_TREEISH:-""}
+docker-compose -f docker-compose.build.yml run --rm -T builder ./bin/clone.sh ${OSCAR_REPO:-""} ${OSCAR_TREEISH:-""}
 docker-compose exec -T db ./bin/populate-db.sh ${LOCATION:-""}
 
 ./bin/setup-faxws.sh

--- a/bin/openosp-build.sh
+++ b/bin/openosp-build.sh
@@ -21,7 +21,7 @@ case "${COMMAND}" in
         if [ -z "$WARFILE" ]
         then
             echo "Compiling OSCAR. This may take some time...."
-            docker-compose -f docker-compose.build.yml run builder ./bin/build-oscar.sh
+            docker-compose -f docker-compose.build.yml run --rm builder ./bin/build-oscar.sh
             mv $OSCAR_OUTPUT/oscar/target/oscar-*-SNAPSHOT.war $OSCAR_OUTPUT/oscar.war
         else
             mkdir -p $OSCAR_OUTPUT
@@ -52,7 +52,7 @@ case "${COMMAND}" in
         ;;
     faxws)
         echo "Compiling FaxWS"
-        docker-compose -f docker-compose.build.yml run builder ./bin/build-faxws.sh
+        docker-compose -f docker-compose.build.yml run --rm builder ./bin/build-faxws.sh
 
         echo "Building FaxWs Docker Image"
         docker-compose build faxws

--- a/bin/setup-keys.sh
+++ b/bin/setup-keys.sh
@@ -5,3 +5,10 @@ if [ ! -f ./volumes/ssl.key ] || [ ! -f ./volumes/ssl.crt ] ; then
     openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/C=CA/ST=BC/L=Vancouver/O=OpenOSP/CN=faxws" -keyout ./volumes/ssl.key -out ./volumes/ssl.crt
 fi
 
+# Create an empty chain.pem file
+# If an empty file doesn't exist, then Docker adds chain.pem as a **directory** instead of a file,
+# which results in an "Error response from daemon: error while creating mount source path './volumes/chain.pem': chown ./volumes/chain.pem: operation not permitted"
+# when bringing up the openosp image
+if [ ! -f ./volumes/chain.pem ] ; then
+    touch ./volumes/chain.pem
+fi


### PR DESCRIPTION
2 small improvements:

1. Dispose of docker builder containers after their job is done, and
2. Make sure there's an empty `chain.pem` file in `./volumes` to avoid docker adding that as a **directory** instead of a file -- see the error message in the 42c921d commit