### PR TITLE
Docker command should clean up after itself

### DIFF
--- a/bin/openosp-build.sh
+++ b/bin/openosp-build.sh
@@ -43,7 +43,7 @@ case "${COMMAND}" in
         else
           # Download drugref if we need it.
           echo "Retrieving current DrugRef2 binary"
-          docker run -v $(pwd):/code/ alpine sh -c "apk add curl && cd /code/ && curl -Lo $OSCAR_OUTPUT/drugref2.war $DRUGREF_WAR"
+          docker run --rm -v $(pwd):/code/ alpine sh -c "apk add curl && cd /code/ && curl -Lo $OSCAR_OUTPUT/drugref2.war $DRUGREF_WAR"
         fi
         docker-compose build oscar
         ;;


### PR DESCRIPTION
The alpine container should be discarded after it's done its job, otherwise they just lie around the system taking up space.