### PR TITLE
Build improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ docker/oscar/*.war
 docker/oscar/oscar
 docker/faxws/faxws
 
+tmp/
 .vagrant
 .vagrant.v1.*
 .DS_Store

--- a/bin/build-faxws.sh
+++ b/bin/build-faxws.sh
@@ -1,14 +1,21 @@
 #!/bin/bash
 
-cd docker/faxws
+repo_name='faxws'
+repo_url='https://bitbucket.org/openoscar/faxws.git'
+repo_branch='master'
+repo_path='docker/faxws/faxws'
 
-## Clone
-git clone https://bitbucket.org/openoscar/faxws.git
+echo "Cloning ${repo_name} from ${repo_url} to ${repo_path}"
+if [ -d $repo_path ]; then
+  echo "$repo_path already exists. Delete the directory if you want to recompile from scratch."
+else
+  git clone $repo_url $repo_path --branch $repo_branch
+fi
 
-cd faxws
+cd $repo_path
 
 echo "Remove context xml so we can replace it after WAR extraction."
-rm src/main/webapp/META-INF/context.xml
+rm -f src/main/webapp/META-INF/context.xml
 
 echo "Build FaxWs with Maven..."
 

--- a/bin/build-faxws.sh
+++ b/bin/build-faxws.sh
@@ -12,6 +12,8 @@ rm src/main/webapp/META-INF/context.xml
 
 echo "Build FaxWs with Maven..."
 
-mvn clean
-mvn package
-
+if [[ "${TEST_DURING_BUILD:-}" ]]; then
+  mvn clean package
+else
+  mvn -Dcheckstyle.skip -Dmaven.test.skip=true clean package
+fi

--- a/bin/build-oscar.sh
+++ b/bin/build-oscar.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-
 set -uxo
 
-if [ -f "./local.env" ]
-then
+if [ -f "./local.env" ]; then
     source ./local.env
 fi
 
@@ -18,15 +16,12 @@ export MAVEN_OPTS="-Xms640m -Xmx640m -Xss512k -XX:NewRatio=4 -Djava.net.preferIP
 
 # this repository should have passed unit testing and mvn verify 
 # on the cis before being built here.
-if [[ "${TEST_DURING_BUILD:-}" ]]
-then
+if [[ "${TEST_DURING_BUILD:-}" ]]; then
     mvn clean package
-elif [[ "${DEVELOPMENT_MODE:-}" ]]
-then
+elif [[ "${DEVELOPMENT_MODE:-}" ]]; then
     mvn -T 1C install --offline
 else
     mvn -Dcheckstyle.skip -Dmaven.test.skip=true clean package
 fi
 
 chmod 777 -R ./target/
-

--- a/bin/build-oscar.sh
+++ b/bin/build-oscar.sh
@@ -2,8 +2,8 @@
 
 set -uxo
 
-if [ -f "./local.env" ]; then
-    source ./local.env
+if [ -f './local.env' ]; then
+  source ./local.env
 fi
 
 ./bin/clone.sh ${OSCAR_REPO:-""} ${OSCAR_TREEISH:-""}
@@ -17,11 +17,11 @@ export MAVEN_OPTS="-Xms640m -Xmx640m -Xss512k -XX:NewRatio=4 -Djava.net.preferIP
 # this repository should have passed unit testing and mvn verify 
 # on the cis before being built here.
 if [[ "${TEST_DURING_BUILD:-}" ]]; then
-    mvn clean package
+  mvn clean package
 elif [[ "${DEVELOPMENT_MODE:-}" ]]; then
-    mvn -T 1C install --offline
+  mvn -T 1C install --offline
 else
-    mvn -Dcheckstyle.skip -Dmaven.test.skip=true clean package
+  mvn -Dcheckstyle.skip -Dmaven.test.skip=true clean package
 fi
 
 chmod 777 -R ./target/

--- a/bin/clone.sh
+++ b/bin/clone.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 
-
 set -uxo
 
-repo=${1:-https://countable@bitbucket.org/openoscar/oscar.git}
-branch=${2:-release/Oscar-BC-15}
+repo_name='oscar'
+repo_url=${1:-https://bitbucket.org/openoscar/oscar.git}
+repo_branch=${2:-release/Oscar-BC-15}
+repo_path='docker/oscar/oscar'
 
-echo "Cloning oscar from bitbucket"
-if [ -d "./docker/oscar/oscar" ]; then
-    echo "already cloned"
+echo "Cloning ${repo_name} from ${repo_url} to ${repo_path}"
+if [ -d $repo_path ]; then
+  echo "$repo_path already exists. Delete the directory if you want to recompile from scratch."
 else
-    git clone $repo docker/oscar/oscar
-    cd docker/oscar/oscar
-    git checkout $branch
+  git clone $repo_url $repo_path --branch $repo_branch
 fi

--- a/bin/openosp-bootstrap.sh
+++ b/bin/openosp-bootstrap.sh
@@ -9,8 +9,8 @@ echo "Setting up database..."
 docker-compose up -d db
 sleep 10
 
-docker-compose -f docker-compose.build.yml run --rm -T builder ./bin/clone.sh ${OSCAR_REPO:-""} ${OSCAR_TREEISH:-""}
-docker-compose exec -T db ./bin/populate-db.sh ${LOCATION:-""}
+docker-compose -f docker-compose.build.yml run --rm builder ./bin/clone.sh ${OSCAR_REPO:-""} ${OSCAR_TREEISH:-""}
+docker-compose exec db ./bin/populate-db.sh ${LOCATION:-""}
 
 ./bin/setup-faxws.sh
 

--- a/bin/openosp-build.sh
+++ b/bin/openosp-build.sh
@@ -45,7 +45,7 @@ case $COMPONENT in
         docker-compose build expedius
         ;;
     faxws)
-        echo "Compiling FaxWS"
+        echo "Compiling FaxWS warfile"
         docker-compose -f docker-compose.build.yml run --rm builder ./bin/build-faxws.sh
 
         echo "Building FaxWs Docker Image"

--- a/bin/openosp-build.sh
+++ b/bin/openosp-build.sh
@@ -4,23 +4,24 @@
 
 set -exo
 
-COMMAND=$1
-if [[ $2 != *--* ]]
-then
-  WARFILE=$2
+COMPONENT=$1
+
+if [[ $* == *--test* ]]; then
+    export TEST_DURING_BUILD=1
+    docker-compose up -d db # Need database to be up so it can run tests
+elif [[ $* == *--dev* ]]; then
+    export DEVELOPMENT_MODE=1
+elif [[ $2 != *--* ]]; then
+    WARFILE=$2
 fi
 
-case "${COMMAND}" in
+case $COMPONENT in
     oscar)
         OSCAR_OUTPUT=docker/oscar
-        if [[ "$*" == *--test* ]]
-        then
-            docker-compose up -d db
-        fi
 
-        if [ -z "$WARFILE" ]
-        then
-            echo "Compiling OSCAR. This may take some time...."
+        # Using an existing warfile or compiling from scratch?
+        if [ -z $WARFILE ]; then
+            echo "Compiling OSCAR warfile. This may take some time...."
             docker-compose -f docker-compose.build.yml run --rm builder ./bin/build-oscar.sh
             mv $OSCAR_OUTPUT/oscar/target/oscar-*-SNAPSHOT.war $OSCAR_OUTPUT/oscar.war
         else
@@ -28,26 +29,19 @@ case "${COMMAND}" in
             cp $WARFILE $OSCAR_OUTPUT/oscar.war
         fi
 
-        # download most current binary release of DrugRef2 from the Open OSP repository.
-        # current version released December 30, 2021
-        export DRUGREF_WAR=${DRUGREF_WAR:-"https://bitbucket.org/openoscar/drugref/downloads/drugref2.war"}
-
+        # Download drugref if we need it
+        # For some reason this is only when not testing during build and not in development mode
+        if [ -z $TEST_DURING_BUILD ] && [ -z $DEVELOPMENT_MODE ]; then
+            echo "Retrieving current DrugRef2 binary"
+            export DRUGREF_WAR=${DRUGREF_WAR:-"https://bitbucket.org/openoscar/drugref/downloads/drugref2.war"}
+            docker run --rm -v $(pwd):/code/ alpine sh -c "apk add curl && cd /code/ && curl -Lo $OSCAR_OUTPUT/drugref2.war $DRUGREF_WAR"
+        fi
 
         echo "Building Oscar Docker Image"
-        if [[ "$*" == *--test* ]]
-        then
-            export TEST_DURING_BUILD=1
-        elif [[ "$*" == *--dev* ]]
-        then
-            export DEVELOPMENT_MODE=1
-        else
-          # Download drugref if we need it.
-          echo "Retrieving current DrugRef2 binary"
-          docker run --rm -v $(pwd):/code/ alpine sh -c "apk add curl && cd /code/ && curl -Lo $OSCAR_OUTPUT/drugref2.war $DRUGREF_WAR"
-        fi
         docker-compose build oscar
         ;;
     expedius)
+        echo "Building Expedius Docker Image"
         docker-compose build expedius
         ;;
     faxws)
@@ -58,5 +52,3 @@ case "${COMMAND}" in
         docker-compose build faxws
         ;;
 esac
-
-

--- a/bin/openosp-setup.sh
+++ b/bin/openosp-setup.sh
@@ -124,8 +124,11 @@ if [ ! -d "./volumes/OscarDocument/oscar" ]; then
   mkdir ./volumes/OscarDocument/oscar/document
 fi
 
-docker pull openosp/open-osp
-docker pull openosp/faxws
-
-
-
+ARCH=`uname -m`
+if [[ $ARCH == 'amd64' || $ARCH == 'aarch64' ]]; then
+  echo "Not pulling pre-built docker images as you are on an ARM machine; you'll need to build them yourself."
+else
+  docker pull openosp/open-osp
+  docker pull openosp/expedius
+  docker pull openosp/faxws
+fi

--- a/bin/openosp-setup.sh
+++ b/bin/openosp-setup.sh
@@ -125,7 +125,7 @@ if [ ! -d "./volumes/OscarDocument/oscar" ]; then
 fi
 
 ARCH=`uname -m`
-if [[ $ARCH == 'amd64' || $ARCH == 'aarch64' ]]; then
+if [[ $ARCH == 'arm64' || $ARCH == 'aarch64' ]]; then
   echo "Not pulling pre-built docker images as you are on an ARM machine; you'll need to build them yourself."
 else
   docker pull openosp/open-osp

--- a/bin/openosp-update.sh
+++ b/bin/openosp-update.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ARCH=`uname -m`
-if [[ $ARCH == 'amd64' || $ARCH == 'aarch64' ]]; then
+if [[ $ARCH == 'arm64' || $ARCH == 'aarch64' ]]; then
   echo "Not pulling pre-built docker images as you are on an ARM machine; you'll need to build them yourself."
 else
   echo "Updating OpenOSP image and restarting. This only works if you are set to the release tag."

--- a/bin/openosp-update.sh
+++ b/bin/openosp-update.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 
-echo "Updating OpenOSP image and restarting. This only works if you are set to the release tag."
+ARCH=`uname -m`
+if [[ $ARCH == 'amd64' || $ARCH == 'aarch64' ]]; then
+  echo "Not pulling pre-built docker images as you are on an ARM machine; you'll need to build them yourself."
+else
+  echo "Updating OpenOSP image and restarting. This only works if you are set to the release tag."
 
-docker pull openosp/open-osp:release
-docker pull openosp/expedius:latest
-docker pull openosp/faxws:latest
+  docker pull openosp/open-osp:release
+  docker pull openosp/expedius:latest
+  docker pull openosp/faxws:latest
 
-docker-compose --compatibility up -d
-
+  docker-compose --compatibility up -d
+fi

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -4,11 +4,13 @@ echo "Setting up database..."
 docker-compose up -d db
 sleep 10
 
-echo "Bringing up tomcat"
-docker-compose up -d oscar
+echo "Starting FaxWS..."
+docker-compose up -d faxws
 
-echo "expediting Expedius"
+echo "Expediting Expedius..."
 docker-compose up -d expedius
 
-echo "OSCAR is set up at http://<this host>/oscar"
+echo "Bringing up Oscar..."
+docker-compose up -d oscar
 
+echo "OSCAR is set up at http://<this host>/oscar"

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,8 +1,10 @@
-version: '3'
+version: '3.3'
 
 services:
 
     builder:
+      pull_policy: never
+      image: openosp/builder
       build: docker/builder
       volumes:
         - .:/code

--- a/docker/builder/Dockerfile
+++ b/docker/builder/Dockerfile
@@ -1,9 +1,7 @@
 FROM openjdk:8
 
 # This container builds oscar, and runs mvn tests.
-
+# Install the mariadb-client so we can run tests.
 RUN apt-get update \
- && apt-get install -y maven mariadb-client
-
-# install the mysql client above so we run the tests.
-
+    && apt-get install -y --no-install-recommends maven mariadb-client \
+    && apt-get clean


### PR DESCRIPTION
* Flatten the build logic in `bin/openosp-build.sh`
* Allows the skipping of tests during bulding of faxws, just like during Oscar compilation
* Don't disable TTY in certain `docker-compose` commands
   * disabling TTY can cause a remote server to hang up if running these commands through a tool that communicates with the server via SSH
   * no other `docker-compose run` commands in this app disables TTY, we should be consistent
* Fix `bin/run.sh` script to bring up faxws along with all other services
* Fix `bin/openosp-setup.sh` to add missing docker pull for expedius
* Fix `bin/openosp-setup.sh` and `bin/openosp-update.sh` to avoid pulling pre-built images when on ARM machines as they are compiled for Intel only
   * Eventually we should investigate if it is possible to pre-build universal architecture-agnostic images