### PR TITLE
tomcat 9.0.102 with ubuntu jammy

### DIFF
--- a/docker/expedius/Dockerfile
+++ b/docker/expedius/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0.102-jre8
+FROM tomcat:9.0.102-jre8-temurin-jammy
 
 # Fetch Expedius binary
 RUN wget https://bitbucket.org/colcamexdev/expediusbinary/downloads/Expedius-4.12.21.war

--- a/docker/faxws/Dockerfile
+++ b/docker/faxws/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0.102-jre8
+FROM tomcat:9.0.102-jre8-temurin-jammy
 
 RUN apt-get update \
 #    && apt-get install -y maven \

--- a/docker/oscar/Dockerfile
+++ b/docker/oscar/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0.102-jre8
+FROM tomcat:9.0.102-jre8-temurin-jammy
 
 # Set the locale
 RUN apt-get update && apt-get install -y locales curl iputils-ping


### PR DESCRIPTION
downgraded environment to jammy to accommodate PDF conversion tools that do not have a release available for noble at this time.